### PR TITLE
Configure unit tests

### DIFF
--- a/nwb.config.js
+++ b/nwb.config.js
@@ -8,5 +8,8 @@ module.exports = {
         react: 'React'
       }
     }
+  },
+  karma: {
+    testFiles: 'test/unit/*.test.js'
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "clean": "nwb clean-module && nwb clean-demo",
     "prepublishOnly": "npm run build",
     "start": "nwb serve-react-demo",
-    "test": "nwb test-react",
+    "test": "npm run test:unit",
+    "test:unit": "nwb test-react",
     "test:coverage": "nwb test-react --coverage",
     "test:watch": "nwb test-react --server"
   },

--- a/test/unit/index.unit.test.js
+++ b/test/unit/index.unit.test.js
@@ -2,7 +2,7 @@ import expect from 'expect'
 import React from 'react'
 import {render, unmountComponentAtNode} from 'react-dom'
 
-import FullScreen from '../demo/src/components/fullscreen'
+import FullScreen from '../../demo/src/components/fullscreen'
 
 describe('FullScreen', () => {
   let node


### PR DESCRIPTION
I've made some changes to the unit test config that I think makes sense for our unit and acceptance tests. My thinking:

New folder structure 
```
test
    acceptance  // folder for acceptance tests
        myHook.acceptance.test.js // naming convention for acceptance tests
    unit  // folder for unit tests
        myHook.unit.test.js // naming convention for unit tests
```

New test scripts
```
npm run test:acceptance // runs acceptance
npm run test:unit // runs unit
npm run test // runs unit and acceptance (this is what circle calls)
```

The unit part is all added here and I will follow up with the acceptance part. The new folder structure may affect @cianfoley-nearform 's work, I would recommend merging this first before starting on the unit tests