### PR TITLE
Add Apache2 license

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ const fs = useFullScreen()
 
 ## License
 
-Copyright 2018 nearForm
+Copyright 2019 NearForm
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Adds an [Apache2](https://github.com/nearform/pathfinders/blob/master/templates/LICENSE) license to the README, as per the [NearForm open source guidelines](https://github.com/nearform/pathfinders/blob/master/nearform-opensource-guidelines.md).