### PR TITLE
Test geolocation

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 // this file can be removed when we get rid of acceptance tests
 module.exports = {
-  testPathIgnorePatterns: ['/node_modules/', 'test/acceptance']
+  testPathIgnorePatterns: ['/node_modules/', 'test/acceptance'],
+  setupFiles: ['<rootDir>/test/unit/setup.js']
 }

--- a/src/hooks/geolocation.js
+++ b/src/hooks/geolocation.js
@@ -17,5 +17,5 @@ export function useGeolocation(options) {
     return () => navigator.geolocation.clearWatch(watchId)
   }, [options])
 
-  return [position, error]
+  return { position, error }
 }

--- a/storybook/stories/geolocation/README.md
+++ b/storybook/stories/geolocation/README.md
@@ -1,17 +1,17 @@
 ## useGeolocation Hook
 
-The useGeolocation hook gives you current location.  
+The useGeolocation hook gives you current location.
 
 Import as follows:
 
 ```javascript
-import { useGeolocation } from '@nearform/react-browser-hooks' 
+import { useGeolocation } from '@nearform/react-browser-hooks'
 ```
 
 Example of usage:
 
 ```javascript
-const [position, error] = useGeolocation()
+const { position, error } = useGeolocation()
 if (error) {
   return <p>There was an error: {error.message}</p>
 }
@@ -39,9 +39,11 @@ return (
 ```
 
 Parameters:
+
 - options (object): see https://developer.mozilla.org/en-US/docs/Web/API/PositionOptions for more info
 
-Returns an array containing:
+Returns an object containing:
+
 - position(object): https://developer.mozilla.org/en-US/docs/Web/API/Position
   - coords(object): https://developer.mozilla.org/en-US/docs/Web/API/Coordinates
     - accuracy(double): the accuracy of the latitude and longitude properties, expressed in meters,

--- a/storybook/stories/geolocation/geolocation.stories.js
+++ b/storybook/stories/geolocation/geolocation.stories.js
@@ -5,7 +5,7 @@ import readme from './README.md'
 import { withReadme } from 'storybook-readme'
 
 function CurrentLocation() {
-  const [position, error] = useGeolocation()
+  const { position, error } = useGeolocation()
 
   return error ? (
     <p>There was an error: {error.message}</p>

--- a/test/unit/hooks/geolocation.unit.test.js
+++ b/test/unit/hooks/geolocation.unit.test.js
@@ -1,0 +1,105 @@
+import { flushEffects } from 'react-testing-library'
+import { testHook, cleanup } from 'react-proxy-hook'
+import { useGeolocation } from '../../../src'
+
+afterEach(cleanup)
+
+describe('useGeolocation', () => {
+  it('sets initial state to mock Position', () => {
+    let position, error
+    testHook(() => ({ position, error } = useGeolocation()))
+
+    expect(position).toEqual({
+      coords: {},
+      timestamp: 1549358005991
+    })
+
+    expect(error).toBe(null)
+  })
+
+  it('calls getCurrentPosition with options', () => {
+    testHook(() => useGeolocation({ foo: 'bar' }))
+
+    flushEffects()
+
+    expect(navigator.geolocation.getCurrentPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      {
+        foo: 'bar'
+      }
+    )
+  })
+
+  it('returns a position on a successful getCurrentPosition', () => {
+    navigator.geolocation.getCurrentPosition = jest
+      .fn()
+      .mockImplementationOnce((onSuccess) => onSuccess('position'))
+
+    let position, error
+    testHook(() => ({ position, error } = useGeolocation()))
+
+    flushEffects()
+
+    expect(position).toBe('position')
+    expect(error).toBe(null)
+  })
+
+  it('returns an error on an unsuccessful getCurrentPosition', () => {
+    const mockError = new Error('Where are you?')
+
+    navigator.geolocation.getCurrentPosition = jest
+      .fn()
+      .mockImplementationOnce((_, onError) => onError(mockError))
+
+    let error
+    testHook(() => ({ error } = useGeolocation()))
+
+    flushEffects()
+
+    expect(error).toBe(mockError)
+  })
+
+  it('calls watchPosition with options', () => {
+    testHook(() => useGeolocation({ foo: 'bar' }))
+
+    flushEffects()
+
+    expect(navigator.geolocation.watchPosition).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.any(Function),
+      {
+        foo: 'bar'
+      }
+    )
+  })
+
+  it('returns a position on a successful watchPosition', () => {
+    navigator.geolocation.watchPosition = jest
+      .fn()
+      .mockImplementationOnce((onSuccess) => onSuccess('position'))
+
+    let position, error
+    testHook(() => ({ position, error } = useGeolocation()))
+
+    flushEffects()
+
+    expect(position).toBe('position')
+    expect(error).toBe(null)
+  })
+
+  it('returns an error on an unsuccessful watchPosition', () => {
+    const mockError = new Error('Cannot find you!')
+
+    navigator.geolocation.watchPosition = jest
+      .fn()
+      .mockImplementationOnce((_, onError) => onError(mockError))
+
+    let error
+    testHook(() => ({ error } = useGeolocation()))
+
+    flushEffects()
+
+    expect(error).toBe(mockError)
+  })
+})

--- a/test/unit/hooks/orientation.unit.test.js
+++ b/test/unit/hooks/orientation.unit.test.js
@@ -8,7 +8,6 @@ describe('useOrientation', () => {
     let angle, type
     window.screen.orientation = { angle: 0, type: 'portrait-primary' }
     testHook(() => ({ angle, type } = useOrientation()))
-
     expect(angle).toBe(0)
     expect(type).toBe('portrait-primary')
   })

--- a/test/unit/setup.js
+++ b/test/unit/setup.js
@@ -1,0 +1,7 @@
+global.navigator.geolocation = {
+  getCurrentPosition: jest.fn(),
+  watchPosition: jest.fn(),
+  clearWatch: jest.fn()
+}
+
+Date.now = jest.fn(() => 1549358005991) // 05/02/2019


### PR DESCRIPTION
Based on #54 

* Changes `useGeolocation` output to be an object rather than a tuple, for consistency with other hooks
* Adds tests for `useGeolocation`

```
 PASS  test/unit/hooks/geolocation.unit.test.js
  useGeolocation
    ✓ sets initial state to mock Position (18ms)
    ✓ calls getCurrentPosition with options (2ms)
    ✓ returns a position on a successful getCurrentPosition (3ms)
    ✓ returns an error on an unsuccessful getCurrentPosition (1ms)
    ✓ calls watchPosition with options (2ms)
    ✓ returns a position on a successful watchPosition (4ms)
    ✓ returns an error on an unsuccessful watchPosition (2ms)
```