### PR TITLE
Add default state for useOrientation, always return an object

### DIFF
--- a/src/hooks/orientation.js
+++ b/src/hooks/orientation.js
@@ -1,8 +1,16 @@
 import { useState, useEffect } from 'react'
 
+const defaultState = {
+  angle: 0,
+  type: 'landscape-primary'
+}
+
 export function useOrientation() {
   const currentOrientation =
-    typeof window === 'object' ? window.screen.orientation : null
+    typeof window === 'object' && window.screen.orientation
+      ? window.screen.orientation
+      : defaultState
+
   const [state, setState] = useState(currentOrientation)
 
   useEffect(() => {


### PR DESCRIPTION
Fixes #57 

Provides a default within the `useOrientation` hook so that the hook always returns the expected object, even if the API isn't supported.