### PR TITLE
Test orientationchange event

### DIFF
--- a/test/unit/hooks/orientation.unit.test.js
+++ b/test/unit/hooks/orientation.unit.test.js
@@ -1,3 +1,4 @@
+import { fireEvent, flushEffects } from 'react-testing-library'
 import { testHook, cleanup } from 'react-proxy-hook'
 import { useOrientation } from '../../../src'
 
@@ -7,8 +8,30 @@ describe('useOrientation', () => {
   it('sets initial state to window.screen.orientation', () => {
     let angle, type
     window.screen.orientation = { angle: 0, type: 'portrait-primary' }
+
     testHook(() => ({ angle, type } = useOrientation()))
+
     expect(angle).toBe(0)
     expect(type).toBe('portrait-primary')
+  })
+
+  it('updates state on "orientationchange"', () => {
+    let angle, type
+    window.screen.orientation = { angle: 0, type: 'portrait-primary' }
+    testHook(() => ({ angle, type } = useOrientation()))
+
+    flushEffects()
+
+    window.screen.orientation = { angle: 90, type: 'landscape-primary' }
+    fireEvent(
+      window,
+      new Event('orientationchange', {
+        bubbles: false,
+        cancelable: false
+      })
+    )
+
+    expect(angle).toBe(90)
+    expect(type).toBe('landscape-primary')
   })
 })


### PR DESCRIPTION
This adds a test for the orientation hook's "orientationchange" handler. The event is not yet supported, so I had to manually trigger it with `new Event`. For other events you could more easily use one of the [shortcuts](https://testing-library.com/docs/api-events#fireevent-eventname).

There are 2 untested lines, which are the `typeof window !== object` checks