### PR TITLE
Replace experimental flushEffects with act from react-dom/test-utils

### DIFF
--- a/test/unit/hooks/geolocation.unit.test.js
+++ b/test/unit/hooks/geolocation.unit.test.js
@@ -1,5 +1,6 @@
-import { flushEffects } from 'react-testing-library'
 import { testHook, cleanup } from 'react-proxy-hook'
+import { act } from 'react-dom/test-utils'
+
 import { useGeolocation } from '../../../src'
 
 afterEach(cleanup)
@@ -18,9 +19,9 @@ describe('useGeolocation', () => {
   })
 
   it('calls getCurrentPosition with options', () => {
-    testHook(() => useGeolocation({ foo: 'bar' }))
-
-    flushEffects()
+    act(() => {
+      testHook(() => useGeolocation({ foo: 'bar' }))
+    })
 
     expect(navigator.geolocation.getCurrentPosition).toHaveBeenCalledWith(
       expect.any(Function),
@@ -37,9 +38,9 @@ describe('useGeolocation', () => {
       .mockImplementationOnce((onSuccess) => onSuccess('position'))
 
     let position, error
-    testHook(() => ({ position, error } = useGeolocation()))
-
-    flushEffects()
+    act(() => {
+      testHook(() => ({ position, error } = useGeolocation()))
+    })
 
     expect(position).toBe('position')
     expect(error).toBe(null)
@@ -53,17 +54,17 @@ describe('useGeolocation', () => {
       .mockImplementationOnce((_, onError) => onError(mockError))
 
     let error
-    testHook(() => ({ error } = useGeolocation()))
-
-    flushEffects()
+    act(() => {
+      testHook(() => ({ error } = useGeolocation()))
+    })
 
     expect(error).toBe(mockError)
   })
 
   it('calls watchPosition with options', () => {
-    testHook(() => useGeolocation({ foo: 'bar' }))
-
-    flushEffects()
+    act(() => {
+      testHook(() => useGeolocation({ foo: 'bar' }))
+    })
 
     expect(navigator.geolocation.watchPosition).toHaveBeenCalledWith(
       expect.any(Function),
@@ -80,9 +81,9 @@ describe('useGeolocation', () => {
       .mockImplementationOnce((onSuccess) => onSuccess('position'))
 
     let position, error
-    testHook(() => ({ position, error } = useGeolocation()))
-
-    flushEffects()
+    act(() => {
+      testHook(() => ({ position, error } = useGeolocation()))
+    })
 
     expect(position).toBe('position')
     expect(error).toBe(null)
@@ -96,9 +97,9 @@ describe('useGeolocation', () => {
       .mockImplementationOnce((_, onError) => onError(mockError))
 
     let error
-    testHook(() => ({ error } = useGeolocation()))
-
-    flushEffects()
+    act(() => {
+      testHook(() => ({ error } = useGeolocation()))
+    })
 
     expect(error).toBe(mockError)
   })

--- a/test/unit/hooks/mouse-position.unit.test.js
+++ b/test/unit/hooks/mouse-position.unit.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, flushEffects } from 'react-testing-library'
+import { fireEvent } from 'react-testing-library'
 import { testHook, cleanup } from 'react-proxy-hook'
 import { act } from 'react-dom/test-utils'
 
@@ -18,9 +18,10 @@ describe('useMousePosition', () => {
 
   it('updates state on "mousemove"', () => {
     let x, y
-    testHook(() => ({ x, y } = useMousePosition()))
 
-    flushEffects()
+    act(() => {
+      testHook(() => ({ x, y } = useMousePosition()))
+    })
 
     act(() => {
       fireEvent.mouseMove(document.body, { clientX: 100, clientY: 100 })

--- a/test/unit/hooks/orientation.unit.test.js
+++ b/test/unit/hooks/orientation.unit.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, flushEffects } from 'react-testing-library'
+import { fireEvent } from 'react-testing-library'
 import { testHook, cleanup } from 'react-proxy-hook'
 import { act } from 'react-dom/test-utils'
 
@@ -20,9 +20,10 @@ describe('useOrientation', () => {
   it('updates state on "orientationchange"', () => {
     let angle, type
     window.screen.orientation = { angle: 0, type: 'portrait-primary' }
-    testHook(() => ({ angle, type } = useOrientation()))
 
-    flushEffects()
+    act(() => {
+      testHook(() => ({ angle, type } = useOrientation()))
+    })
 
     window.screen.orientation = { angle: 90, type: 'landscape-primary' }
 

--- a/test/unit/hooks/page-visibility.unit.test.js
+++ b/test/unit/hooks/page-visibility.unit.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, flushEffects } from 'react-testing-library'
+import { fireEvent } from 'react-testing-library'
 import { testHook, cleanup } from 'react-proxy-hook'
 import { act } from 'react-dom/test-utils'
 
@@ -48,9 +48,10 @@ describe('usePageVisibility', () => {
     it('updates state on the "visibilitychange" event', () => {
       let visible
       document.hidden = false
-      testHook(() => (visible = usePageVisibility()))
 
-      flushEffects()
+      act(() => {
+        testHook(() => (visible = usePageVisibility()))
+      })
 
       document.hidden = true
 
@@ -109,9 +110,10 @@ describe('usePageVisibility', () => {
     it('updates state on the "msvisibilitychange" event', () => {
       let visible
       document.msHidden = false
-      testHook(() => (visible = usePageVisibility()))
 
-      flushEffects()
+      act(() => {
+        testHook(() => (visible = usePageVisibility()))
+      })
 
       document.msHidden = true
       act(() => {
@@ -169,9 +171,10 @@ describe('usePageVisibility', () => {
     it('updates state on the "webkitvisibilitychange" event', () => {
       let visible
       document.webkitHidden = false
-      testHook(() => (visible = usePageVisibility()))
 
-      flushEffects()
+      act(() => {
+        testHook(() => (visible = usePageVisibility()))
+      })
 
       document.webkitHidden = true
       act(() => {


### PR DESCRIPTION
We have been relying on an experimental `flushEffects` from `react-testing-library` to force effects to run when testing hooks. That has [since been removed](https://github.com/kentcdodds/react-testing-library/pull/278) in favour of using [`act` from `react-dom/test-utils`](https://reactjs.org/docs/test-utils.html#act), as that also causes the effects to run. I've swapped all uses of `flushEffects` to use `act` instead.