### PR TITLE
Replace react-proxy-hook with react-testing-library

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "prettier": "^1.16.4",
     "react": "^16.8.0",
     "react-dom": "^16.8.0",
-    "react-proxy-hook": "^0.4.2",
+    "react-testing-library": "^5.5.0",
     "storybook-readme": "^4.0.5",
     "testcafe": "^0.23.3"
   },

--- a/test/unit/hooks/geolocation.unit.test.js
+++ b/test/unit/hooks/geolocation.unit.test.js
@@ -1,4 +1,4 @@
-import { testHook, cleanup } from 'react-proxy-hook'
+import { testHook, cleanup } from 'react-testing-library'
 import { act } from 'react-dom/test-utils'
 
 import { useGeolocation } from '../../../src'

--- a/test/unit/hooks/mouse-position.unit.test.js
+++ b/test/unit/hooks/mouse-position.unit.test.js
@@ -1,5 +1,4 @@
-import { fireEvent } from 'react-testing-library'
-import { testHook, cleanup } from 'react-proxy-hook'
+import { testHook, cleanup, fireEvent } from 'react-testing-library'
 import { act } from 'react-dom/test-utils'
 
 import { useMousePosition } from '../../../src'

--- a/test/unit/hooks/orientation.unit.test.js
+++ b/test/unit/hooks/orientation.unit.test.js
@@ -1,5 +1,4 @@
-import { fireEvent } from 'react-testing-library'
-import { testHook, cleanup } from 'react-proxy-hook'
+import { testHook, cleanup, fireEvent } from 'react-testing-library'
 import { act } from 'react-dom/test-utils'
 
 import { useOrientation } from '../../../src'

--- a/test/unit/hooks/page-visibility.unit.test.js
+++ b/test/unit/hooks/page-visibility.unit.test.js
@@ -1,5 +1,4 @@
-import { fireEvent } from 'react-testing-library'
-import { testHook, cleanup } from 'react-proxy-hook'
+import { testHook, cleanup, fireEvent } from 'react-testing-library'
 import { act } from 'react-dom/test-utils'
 
 import { usePageVisibility } from '../../../src'

--- a/test/unit/hooks/scroll.unit.test.js
+++ b/test/unit/hooks/scroll.unit.test.js
@@ -1,5 +1,4 @@
-import { fireEvent } from 'react-testing-library'
-import { testHook, cleanup } from 'react-proxy-hook'
+import { testHook, cleanup, fireEvent } from 'react-testing-library'
 import { act } from 'react-dom/test-utils'
 
 import { useScroll } from '../../../src'


### PR DESCRIPTION
The latest release of react-testing-library includes the helpers from react-proxy-hook