### PR TITLE
remove use from hook name in docs

### DIFF
--- a/storybook/stories/fullscreen/README.md
+++ b/storybook/stories/fullscreen/README.md
@@ -1,6 +1,6 @@
-## useFullScreen Hook
+## FullScreen Hook
 
-The useFullScreen hook allows a page or element to occupy the full screen.
+The FullScreen hook allows a page or element to occupy the full screen.
 
 Import as follows:
 

--- a/storybook/stories/geolocation/README.md
+++ b/storybook/stories/geolocation/README.md
@@ -1,6 +1,6 @@
-## useGeolocation Hook
+## Geolocation Hook
 
-The useGeolocation hook gives you current location.
+The Geolocation hook gives you current location.
 
 Import as follows:
 

--- a/storybook/stories/media-controls/README.md
+++ b/storybook/stories/media-controls/README.md
@@ -1,6 +1,6 @@
-## useMediaControls Hook
+## MediaControls Hook
 
-The useMediaControls hook gives you access to the `HTMLMediaElement` API. Create custom controls for your media.
+The MediaControls hook gives you access to the `HTMLMediaElement` API. Create custom controls for your media.
 
 Import as follows:
 

--- a/storybook/stories/mouse-position/README.md
+++ b/storybook/stories/mouse-position/README.md
@@ -1,6 +1,6 @@
-## useMousePosition Hook
+## MousePosition Hook
 
-The useMousePosition hook listens for changes to mouse position.  
+The MousePosition hook listens for changes to mouse position.  
 
 Import as follows:
 

--- a/storybook/stories/orientation/README.md
+++ b/storybook/stories/orientation/README.md
@@ -1,6 +1,6 @@
-## useOrientation Hook
+## Orientation Hook
 
-The useOrientation hook gives you device orientation.  
+The Orientation hook gives you device orientation.  
 
 Import as follows:
 


### PR DESCRIPTION
simple update to docs to remove the word use from the hook names in storybook docs