### PR TITLE
Server-side rendering safety & sensible defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ const fs = useFullScreen()
 <button onClick={fs.toggle}>{fs.fullScreen ? 'Close' : 'Open'}</button>
 ```
 
+### Server-side rendering
+
+Sensible defaults are provided to allow each hook to be safely used when rendering on the server.
+
 [build-badge]: https://img.shields.io/travis/user/repo/master.png?style=flat-square
 [build]: https://travis-ci.org/user/repo
 [npm-badge]: https://img.shields.io/npm/v/npm-package.png?style=flat-square

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nearform/react-browser-hooks",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "react-browser-hooks React component",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,5 @@
+export const IS_SERVER = !(
+  typeof window !== 'undefined' &&
+  window.document &&
+  window.document.createElement
+)

--- a/src/hooks/fullscreen.js
+++ b/src/hooks/fullscreen.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { IS_SERVER } from '../constants'
 import { useResize } from './resize'
 
 // determine if we are in fullscreen mode and why
@@ -26,13 +27,13 @@ export function isFullScreenElement(el) {
 }
 
 export function useFullScreen(options = {}) {
-  const docEl = document.documentElement
   const fsEl = options && options.element
-  const [fullScreen, setFullScreen] = useState(isFullScreenElement(fsEl))
+  const initialState = IS_SERVER ? false : isFullScreenElement(fsEl)
+  const [fullScreen, setFullScreen] = useState(initialState)
 
   // access various open fullscreen methods
   function openFullScreen() {
-    const el = (fsEl && fsEl.current) || docEl
+    const el = (fsEl && fsEl.current) || document.documentElement
 
     if (el.requestFullscreen) return el.requestFullscreen()
     if (el.mozRequestFullScreen) return el.mozRequestFullScreen()
@@ -77,6 +78,7 @@ export function useFullScreen(options = {}) {
 }
 
 export function getSizeInfo() {
+  if (IS_SERVER) return {}
   return {
     screenTop: window.screenTop,
     screenY: window.screenY,
@@ -102,11 +104,10 @@ export function isFullScreenSize(sizeInfo) {
 
 export function useFullScreenBrowser() {
   const size = useResize()
-
   const initialSizeInfo = getSizeInfo()
 
   const [fullScreen, setFullScreen] = useState(
-    isFullScreenSize(initialSizeInfo)
+    IS_SERVER ? false : isFullScreenSize(initialSizeInfo)
   )
   const [sizeInfo, setSizeInfo] = useState(initialSizeInfo)
 

--- a/src/hooks/online.js
+++ b/src/hooks/online.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { IS_SERVER } from '../constants'
 
 //@todo: perhaps polling approach for older browsers as an option
 //e.g. favicon polling
@@ -10,7 +11,9 @@ export function useOnline() {
   }
 
   function getOnlineStatus() {
-    return window.navigator && window.navigator.onLine ? true : false
+    return IS_SERVER || (window.navigator && window.navigator.onLine)
+      ? true
+      : false
   }
 
   useEffect(() => {

--- a/src/hooks/orientation.js
+++ b/src/hooks/orientation.js
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { IS_SERVER } from '../constants'
 
 const defaultState = {
   angle: 0,
@@ -7,7 +8,7 @@ const defaultState = {
 
 export function useOrientation() {
   const currentOrientation =
-    typeof window === 'object' && window.screen.orientation
+    !IS_SERVER && window.screen.orientation
       ? window.screen.orientation
       : defaultState
 
@@ -15,7 +16,6 @@ export function useOrientation() {
 
   useEffect(() => {
     const handler = () => setState(window.screen.orientation)
-    if (typeof window !== 'object') return
 
     window.addEventListener('orientationchange', handler)
     return () => window.removeEventListener('orientationchange', handler)

--- a/src/hooks/page-visibility.js
+++ b/src/hooks/page-visibility.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { IS_SERVER } from '../constants'
 
 /**
  * Function to grab the visibility prop strings
@@ -8,8 +9,11 @@ import { useEffect, useState } from 'react'
  *  and visibilityChange properties
  */
 const getVisibilityProps = () => {
+  if (IS_SERVER) return {}
+
   let hidden
   let visibilityChange
+
   if (typeof document.hidden !== 'undefined') {
     // Opera 12.10 and Firefox 18 and later support
     hidden = 'hidden'
@@ -31,7 +35,7 @@ const getVisibilityProps = () => {
  */
 export const usePageVisibility = () => {
   const { hidden, visibilityChange } = getVisibilityProps()
-  const [visible, setVisible] = useState(!document[hidden])
+  const [visible, setVisible] = useState(IS_SERVER ? true : !document[hidden])
   const handler = () => setVisible(!document[hidden])
   useEffect(() => {
     document.addEventListener(visibilityChange, handler)

--- a/src/hooks/resize.js
+++ b/src/hooks/resize.js
@@ -1,7 +1,13 @@
 import { useState, useEffect } from 'react'
+import { IS_SERVER } from '../constants'
+
+const defaultState = {
+  height: null,
+  width: null
+}
 
 export function useResize() {
-  const [size, setSize] = useState(getWindowSize())
+  const [size, setSize] = useState(IS_SERVER ? defaultState : getWindowSize())
 
   function handleResize() {
     setSize(getWindowSize())

--- a/src/hooks/scroll.js
+++ b/src/hooks/scroll.js
@@ -1,9 +1,10 @@
 import { useState, useEffect } from 'react'
+import { IS_SERVER } from '../constants'
 
 export function useScroll() {
   const [pos, setPos] = useState({
-    top: window.scrollY,
-    left: window.scrollX
+    top: IS_SERVER ? 0 : window.scrollY,
+    left: IS_SERVER ? 0 : window.scrollX
   })
 
   function handleScroll() {

--- a/test/unit/hooks/fullscreen.unit.test.js
+++ b/test/unit/hooks/fullscreen.unit.test.js
@@ -3,6 +3,7 @@ import { testHook, cleanup, fireEvent, render } from 'react-testing-library'
 import { act } from 'react-dom/test-utils'
 
 import { useFullScreen, useFullScreenBrowser } from '../../../src'
+import * as constants from '../../../src/constants'
 
 afterEach(cleanup)
 
@@ -23,6 +24,26 @@ beforeEach(() => {
 
 describe('useFullScreen', () => {
   describe('initial state', () => {
+    describe('when rendered on the server', () => {
+      beforeAll(() => {
+        constants.IS_SERVER = true
+      })
+
+      afterAll(() => {
+        constants.IS_SERVER = false
+      })
+
+      it('defaults to false', () => {
+        let fullScreen
+        document.fullscreenElement = testElementRef.current
+        testHook(
+          () => ({ fullScreen } = useFullScreen({ element: testElementRef }))
+        )
+
+        expect(fullScreen).toBe(false)
+      })
+    })
+
     describe('with options and element ref', () => {
       it('uses document.fullscreenElement', () => {
         let fullScreen

--- a/test/unit/hooks/online.unit.test.js
+++ b/test/unit/hooks/online.unit.test.js
@@ -2,6 +2,7 @@ import { testHook, cleanup, fireEvent } from 'react-testing-library'
 import { act } from 'react-dom/test-utils'
 
 import { useOnline } from '../../../src'
+import * as constants from '../../../src/constants'
 
 let onLineGetter
 
@@ -12,6 +13,23 @@ beforeEach(() => {
 afterEach(cleanup)
 
 describe('useOnline', () => {
+  describe('when rendered on the server', () => {
+    beforeAll(() => {
+      constants.IS_SERVER = true
+    })
+
+    afterAll(() => {
+      constants.IS_SERVER = false
+    })
+
+    it('defaults to true', () => {
+      let status
+      testHook(() => ({ status } = useOnline()))
+
+      expect(status).toBe(true)
+    })
+  })
+
   it('sets initial state to window.navigator.onLine', () => {
     let online
 

--- a/test/unit/hooks/online.unit.test.js
+++ b/test/unit/hooks/online.unit.test.js
@@ -23,10 +23,10 @@ describe('useOnline', () => {
     })
 
     it('defaults to true', () => {
-      let status
-      testHook(() => ({ status } = useOnline()))
+      let online
+      testHook(() => (online = useOnline()))
 
-      expect(status).toBe(true)
+      expect(online).toBe(true)
     })
   })
 

--- a/test/unit/hooks/page-visibility.unit.test.js
+++ b/test/unit/hooks/page-visibility.unit.test.js
@@ -2,10 +2,28 @@ import { testHook, cleanup, fireEvent } from 'react-testing-library'
 import { act } from 'react-dom/test-utils'
 
 import { usePageVisibility } from '../../../src'
+import * as constants from '../../../src/constants'
 
 afterEach(cleanup)
 
 describe('usePageVisibility', () => {
+  describe('when rendered on the server', () => {
+    beforeAll(() => {
+      constants.IS_SERVER = true
+    })
+
+    afterAll(() => {
+      constants.IS_SERVER = false
+    })
+
+    it('defaults to visible', () => {
+      let visible
+      testHook(() => (visible = usePageVisibility()))
+
+      expect(visible).toBe(true)
+    })
+  })
+
   describe('document.hidden', () => {
     beforeEach(() => {
       let hidden = false

--- a/test/unit/hooks/resize.unit.test.js
+++ b/test/unit/hooks/resize.unit.test.js
@@ -2,10 +2,30 @@ import { testHook, cleanup, fireEvent } from 'react-testing-library'
 import { act } from 'react-dom/test-utils'
 
 import { useResize } from '../../../src'
+import * as constants from '../../../src/constants'
 
 afterEach(cleanup)
 
 describe('useResize', () => {
+  describe('when rendered on the server', () => {
+    beforeAll(() => {
+      constants.IS_SERVER = true
+    })
+
+    afterAll(() => {
+      constants.IS_SERVER = false
+    })
+
+    it('defaults to null, null', () => {
+      let width, height
+
+      testHook(() => ({ width, height } = useResize()))
+
+      expect(width).toBe(null)
+      expect(height).toBe(null)
+    })
+  })
+
   it('sets initial state to window.inner* values', () => {
     let width, height
 

--- a/test/unit/hooks/scroll.unit.test.js
+++ b/test/unit/hooks/scroll.unit.test.js
@@ -2,10 +2,30 @@ import { testHook, cleanup, fireEvent } from 'react-testing-library'
 import { act } from 'react-dom/test-utils'
 
 import { useScroll } from '../../../src'
+import * as constants from '../../../src/constants'
 
 afterEach(cleanup)
 
 describe('useScroll', () => {
+  describe('when rendered on the server', () => {
+    beforeAll(() => {
+      constants.IS_SERVER = true
+    })
+
+    afterAll(() => {
+      constants.IS_SERVER = false
+    })
+
+    it('defaults to 0, 0', () => {
+      let top, left
+
+      testHook(() => ({ top, left } = useScroll()))
+
+      expect(top).toBe(0)
+      expect(left).toBe(0)
+    })
+  })
+
   it('sets initial state to window.scroll values', () => {
     let top, left
 


### PR DESCRIPTION
Resolves #31 

* Put guards around the usage of the `window` object to prevent uncaught exceptions when rendering on the server
* Provide sensible defaults when rendered on the server
