### PR TITLE
Default export UMD entry file

### DIFF
--- a/nwb.config.js
+++ b/nwb.config.js
@@ -4,6 +4,7 @@ module.exports = {
     esModules: true,
     umd: {
       global: 'ReactBrowserHooks',
+      entry: './umd.js',
       externals: {
         react: 'React'
       }

--- a/umd.js
+++ b/umd.js
@@ -1,0 +1,2 @@
+import * as hooks from './src/index'
+export default hooks


### PR DESCRIPTION
Provides a different entry point for the UMD build that has a default export as that's a requirement in the [`nwb`](https://github.com/insin/nwb) build. This library currently uses named exports in the main entry point [`src/index.js`](https://github.com/nearform/react-browser-hooks/blob/master/src/index.js).

See the [UMD configuration docs](https://github.com/insin/nwb/blob/master/docs/Configuration.md#umd-string--object--false) for more details.

Fixes #106 