### PR TITLE
Test fullscreen

### DIFF
--- a/storybook/stories/fullscreen/fullscreen.stories.js
+++ b/storybook/stories/fullscreen/fullscreen.stories.js
@@ -9,7 +9,10 @@ function BrowserFullScreen() {
   const fs = useFullScreen({ element })
   const fsb = useFullScreenBrowser()
   return (
-    <div ref={element} style={{ backgroundColor: '#f4f4f2' }}>
+    <div
+      ref={element}
+      className="fullscreen-demo"
+      style={{ backgroundColor: '#f4f4f2' }}>
       <h2>Browser FullScreen Demo</h2>
       <p>
         {fs.fullScreen && fsb.fullScreen && 'Browser in fullscreen mode'}
@@ -17,7 +20,7 @@ function BrowserFullScreen() {
         {!fs.fullScreen && !fsb.fullScreen && 'Browser not in fullscreen mode'}
       </p>
       <div>
-        <button onClick={fs.toggle}>{'Toggle'}</button>
+        <button onClick={fs.toggle}>Toggle</button>
         <button onClick={fs.open} disabled={fs.fullScreen}>
           {'Open'}
         </button>

--- a/test/acceptance/hooks/fullscreen.acceptance.test.js
+++ b/test/acceptance/hooks/fullscreen.acceptance.test.js
@@ -1,0 +1,57 @@
+import globals from '../globals'
+import Storybook from '../storybook'
+
+const storybook = new Storybook()
+
+fixture('Fullscreen Hook')
+  .page(
+    globals.url +
+      '/?selectedKind=FullScreen&selectedStory=Default&full=0&addons=1&stories=1&panelRight=1&addonPanel=REACT_STORYBOOK%2Freadme%2Fpanel'
+  )
+  .beforeEach((t) => t.switchToIframe(storybook.iframe))
+  .afterEach((t) => t.switchToMainWindow())
+
+test('The fullscreen demo is rendered', async (t) => {
+  const { title } = storybook.hooks.fullscreen
+  await t.expect(title.textContent).contains('FullScreen Demo')
+})
+
+test('The fullscreen demo defaults to fullScreen === false', async (t) => {
+  const { description, fullscreen } = storybook.hooks.fullscreen
+  await t
+    .expect(description.textContent)
+    .contains('Browser not in fullscreen mode')
+    .expect(fullscreen.textContent)
+    .contains('"fullScreen": false')
+})
+
+// fullscreen not yet supported by testcafe: https://github.com/DevExpress/testcafe/issues/3514
+
+// test('The toggle button enters fullscreen mode from non-fullscreen', async (t) => {
+//   const { description, fullscreen, toggleButton } = storybook.hooks.fullscreen
+//   await t
+//     .expect(description.textContent)
+//     .contains('Browser not in fullscreen mode')
+//     .expect(fullscreen.textContent)
+//     .contains('"fullScreen": false')
+//     .click(toggleButton)
+//     .expect(description.textContent)
+//     .contains('Browser in fullscreen mode')
+//     .expect(fullscreen.textContent)
+//     .contains('"fullScreen": true')
+// })
+
+// test('The toggle button exits fullscreen mode from fullscreen', async (t) => {
+//   const { description, fullscreen, toggleButton } = storybook.hooks.fullscreen
+//   await t
+//     .click(toggleButton)
+//     .expect(description.textContent)
+//     .contains('Browser in fullscreen mode')
+//     .expect(fullscreen.textContent)
+//     .contains('"fullScreen": true')
+//     .click(toggleButton)
+//     .expect(description.textContent)
+//     .contains('Browser not in fullscreen mode')
+//     .expect(fullscreen.textContent)
+//     .contains('"fullScreen": false')
+// })

--- a/test/acceptance/storybook.js
+++ b/test/acceptance/storybook.js
@@ -8,6 +8,20 @@ class Hook {
   }
 }
 
+class FullscreenHook extends Hook {
+  constructor(className) {
+    super(className)
+
+    const buttons = this.demo.find('button')
+    this.toggleButton = buttons.nth(0)
+    this.openButton = buttons.nth(1)
+    this.closeButton = buttons.nth(2)
+
+    this.description = this.demo.find('p')
+    this.fullscreen = this.demo.find('pre')
+  }
+}
+
 class MediaControlsHook extends Hook {
   constructor(className) {
     super(className)
@@ -41,6 +55,7 @@ export default class Storybook {
   constructor() {
     this.iframe = Selector('iframe#storybook-preview-iframe')
     this.hooks = {
+      fullscreen: new FullscreenHook('.fullscreen-demo'),
       mediaControls: new MediaControlsHook('.media-controls-demo'),
       mousePosition: new MousePositionHook('.mouse-position-demo')
     }

--- a/test/unit/hooks/media-controls.unit.test.js
+++ b/test/unit/hooks/media-controls.unit.test.js
@@ -1,5 +1,5 @@
 import React, { useRef } from 'react'
-import { act, cleanup, renderHook } from 'react-hooks-testing-library'
+import { act, cleanup } from 'react-hooks-testing-library'
 import { fireEvent, render } from 'react-testing-library'
 
 import { useMediaControls } from '../../../src'


### PR DESCRIPTION
### Add fullscreen acceptance tests

I have commented out some of the tests. That is because testcafe does [not yet support](https://github.com/DevExpress/testcafe/issues/3514) fullscreen (and other events that require real user interaction). We will have to uncomment them once that feature has been added.