### PR TITLE
Increase polling timeout to 10m

### DIFF
--- a/bin/acceptance.js
+++ b/bin/acceptance.js
@@ -43,7 +43,7 @@ async function main() {
 
     async function waitForNetlifyDeploy(deployId, options = {}) {
       options.rate = options.rate || 30000 // 30s default
-      options.timeout = options.timeout || 300000 // 5m default
+      options.timeout = options.timeout || 600000 // 10m default
       options.total = options.total || 0
 
       const { summary } = await netlify


### PR DESCRIPTION
The previous 5m timeout was hit while waiting for netlify to deploy the latest master branch. I'n increasing the limit to 10 in this pr.