### PR TITLE
Fix browserstack build id

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,11 @@ jobs:
       BROWSERSTACK_PARALLEL_RUNS: '5'
       BROWSERSTACK_USE_AUTOMATE: '1'
       BROWSERSTACK_PROJECT_NAME: 'react-browser-hooks'
-      BROWSERSTACK_BUILD_ID: ${CIRCLE_BRANCH}
     steps:
+      - run:
+          name: setup dynamic environment variables
+          command: |
+              echo 'export BROWSERSTACK_BUILD_ID="$CIRCLE_BRANCH"' >> $BASH_ENV
       - checkout
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       BROWSERSTACK_PARALLEL_RUNS: '5'
       BROWSERSTACK_USE_AUTOMATE: '1'
       BROWSERSTACK_PROJECT_NAME: 'react-browser-hooks'
-      BROWSERSTACK_BUILD_ID: '$CIRCLE_BRANCH'
+      BROWSERSTACK_BUILD_ID: ${CIRCLE_BRANCH}
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
String interpolation for env vars is no longer supported in circleci 2.0. This pr applies a workaround suggested in [the docs](https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-shell-command)