### PR TITLE
Fix CI builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "babel-loader": "^8.0.5",
     "eslint": "^6.0.0",
     "eslint-config-prettier": "^4.1.0",
-    "eslint-config-react-app": "^4.0.0",
+    "eslint-config-react-app": "^3.0.8",
     "eslint-plugin-flowtype": "^3.5.1",
     "eslint-plugin-import": "^2.16.0",
     "eslint-plugin-jsx-a11y": "^6.2.1",


### PR DESCRIPTION
### What does this PR do?

Upgrading dev dependency `eslint-config-react-app` from `v3.x` to `v4.x` is causing linting to fail due to this bug: https://github.com/facebook/create-react-app/issues/7218 . This PR reverts the dependency back to it's previous version.

### Related issues

https://github.com/facebook/create-react-app/issues/7218
https://github.com/facebook/create-react-app/pull/7219

### Checklist

- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)
- [x] I have added or updated any relevant documentation
- [x] I have added or updated any relevant tests
