### PR TITLE
fix typo in storybook

### DIFF
--- a/storybook/stories/mouse-position/README.md
+++ b/storybook/stories/mouse-position/README.md
@@ -11,7 +11,7 @@ import { useMousePosition } from 'react-browser-hooks'
 Example of usage:
 
 ```javascript
-const { x, y } = useMousePosition(60)
+const { x, y } = useMousePosition()
 <p>X: {x}px, Y: {y}px</p>
 ```
 


### PR DESCRIPTION
### What does this PR do?

looking at [current implementation](https://github.com/nearform/react-browser-hooks/blob/8caf19fc833b53fcbdfb895a9927932ad2610ed8/src/hooks/mouse-position.js#L3) the hook input `60` seems to be a typo


- [x] I have checked the [contributing document](../blob/master/CONTRIBUTING.md)